### PR TITLE
Start Linux workspace with placeholder CLI

### DIFF
--- a/workspace-linux/IMPLEMENTATION_PLAN.md
+++ b/workspace-linux/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,56 @@
+# Linux CLI Implementation Plan
+
+This document outlines a start-to-finish roadmap for bringing the macOS MIDI2 Reader application to Linux using the existing `workspace-linux` Swift package.
+
+## 1. Establish Core Infrastructure
+1. **PDF Abstraction Layer**
+   - Finalize `PDFDocument`, `PDFPage`, and related protocols to hide platform-specific PDF APIs.
+   - Provide a concrete Linux implementation backed by [Poppler](https://poppler.freedesktop.org/) via a SwiftPM system module.
+2. **Rendering Backend**
+   - Integrate Cairo for rasterizing pages to PNG.
+   - Ensure the rendering API mirrors macOS `PDFKit` scaling and coordinate conventions.
+3. **Text Extraction**
+   - Use Poppler's text interfaces to expose line-by-line text with bounding boxes.
+   - Implement utilities to normalize whitespace and map Poppler coordinates to rendered images.
+
+## 2. Port Midi2Core
+1. **Readable Exporter**
+   - Reuse existing parsing logic while swapping PDFKit calls for the new abstraction.
+   - Verify Markdown anchors and bounding boxes match macOS output.
+2. **Facsimile Exporter**
+   - Render each page to PNG with Cairo, mirroring color space and DPI.
+   - Generate `facsimile.html` with deep-link rectangles identical to the Mac version.
+3. **Utility Exporters**
+   - Port `TextExtractor`, `TableExtractor`, and any helpers that interact with PDFKit.
+
+## 3. Command-Line Interface
+1. **Feature Parity**
+   - Implement `midi2-export` options for page ranges, selective export, and verbosity.
+   - Ensure identical command syntax across platforms.
+2. **Error Handling & Logging**
+   - Provide descriptive messages and exit codes suitable for automation.
+3. **Packaging**
+   - Add `--version` and `--help` flags, integrating Swift ArgumentParser if needed.
+
+## 4. Testing & Validation
+1. **Unit Tests**
+   - Add tests for PDF abstraction, exporters, and CLI argument parsing.
+2. **Regression Suites**
+   - Compare PNG hashes and `specdoc.json` SHA-256 between macOS and Linux outputs.
+3. **CI Integration**
+   - Configure GitHub Actions to build and test on Ubuntu.
+
+## 5. Distribution
+1. **Dependencies**
+   - Provide scripts or Dockerfiles installing Poppler, Cairo, and other native libs.
+2. **Binary Releases**
+   - Produce static binaries or container images for easy deployment in FountainAI.
+3. **Documentation**
+   - Update project README with Linux build instructions and usage examples.
+
+## 6. Future Enhancements
+- Implement an OpenAPI wrapper around the CLI for remote invocation.
+- Explore a minimal cross-platform GUI using GTK if interactive use becomes necessary.
+
+---
+This plan tracks the macOS app's capabilities while enabling a headless, automation-friendly Linux workflow.

--- a/workspace-linux/Package.swift
+++ b/workspace-linux/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "Midi2Linux",
+    products: [
+        .library(name: "Midi2Core", targets: ["Midi2Core"]),
+        .executable(name: "midi2-export", targets: ["midi2-export"])
+    ],
+    targets: [
+        .target(name: "Midi2Core"),
+        .executableTarget(name: "midi2-export", dependencies: ["Midi2Core"]),
+        .testTarget(name: "Midi2CoreTests", dependencies: ["Midi2Core"])
+    ]
+)

--- a/workspace-linux/Sources/Midi2Core/PDFDocument.swift
+++ b/workspace-linux/Sources/Midi2Core/PDFDocument.swift
@@ -1,0 +1,20 @@
+public protocol PDFDocument {
+    var pageCount: Int { get }
+    init(path: String) throws
+    func text(at page: Int) -> String
+}
+
+#if os(Linux)
+/// Placeholder implementation. Integration with Poppler or PDFium will live here.
+public struct PopplerPDFDocument: PDFDocument {
+    public let pageCount: Int
+    public init(path: String) throws {
+        // TODO: load document using Poppler
+        self.pageCount = 0
+    }
+    public func text(at page: Int) -> String {
+        // TODO: extract text for page
+        return ""
+    }
+}
+#endif

--- a/workspace-linux/Sources/midi2-export/main.swift
+++ b/workspace-linux/Sources/midi2-export/main.swift
@@ -1,0 +1,8 @@
+import Midi2Core
+
+@main
+struct Midi2Export {
+    static func main() {
+        print("midi2-export linux placeholder")
+    }
+}

--- a/workspace-linux/Tests/Midi2CoreTests/Midi2CoreTests.swift
+++ b/workspace-linux/Tests/Midi2CoreTests/Midi2CoreTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import Midi2Core
+
+final class Midi2CoreTests: XCTestCase {
+    func testPlaceholder() throws {
+        XCTAssertNoThrow(_ = try PopplerPDFDocument(path: "/tmp/none"))
+    }
+}


### PR DESCRIPTION
## Summary
- Create `workspace-linux` Swift package for Linux development
- Define `PDFDocument` protocol with stub `PopplerPDFDocument` implementation
- Add placeholder `midi2-export` CLI and basic test scaffolding
- Document a full Linux CLI implementation plan aligning with the macOS app

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_6897641337188333b62ce41d3fe09029