### PR TITLE
Add Cairo-based PNG rendering for Linux

### DIFF
--- a/workspace-linux/Package.swift
+++ b/workspace-linux/Package.swift
@@ -7,6 +7,9 @@ let package = Package(
         .library(name: "Midi2Core", targets: ["Midi2Core"]),
         .executable(name: "midi2-export", targets: ["midi2-export"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/PureSwift/Cairo.git", branch: "master")
+    ],
     targets: [
         .systemLibrary(
             name: "CPoppler",
@@ -17,7 +20,10 @@ let package = Package(
         ),
         .target(
             name: "Midi2Core",
-            dependencies: ["CPoppler"]
+            dependencies: [
+                "CPoppler",
+                .product(name: "Cairo", package: "Cairo")
+            ]
         ),
         .executableTarget(
             name: "midi2-export",

--- a/workspace-linux/Sources/Midi2Core/CairoRenderer.swift
+++ b/workspace-linux/Sources/Midi2Core/CairoRenderer.swift
@@ -1,0 +1,34 @@
+#if os(Linux)
+import Foundation
+import Cairo
+
+public struct CairoRenderer {
+    /// Render a PDF page to a PNG file using Cairo at the specified DPI and color space.
+    /// - Parameters:
+    ///   - page: The PDF page to render.
+    ///   - url: Destination file URL.
+    ///   - dpi: Output resolution in dots-per-inch.
+    ///   - format: Cairo image format representing the desired color space.
+    public static func render(page: PDFPage, to url: URL, dpi: Double, format: Cairo.ImageFormat = .argb32) throws {
+        let bounds = page.bounds(for: .mediaBox)
+        let scale = dpi / 72.0
+        let widthPx = Int((bounds.width * scale).rounded(.toNearestOrAwayFromZero))
+        let heightPx = Int((bounds.height * scale).rounded(.toNearestOrAwayFromZero))
+
+        let surface = try Surface.Image(format: format, width: widthPx, height: heightPx)
+        let ctx = Context(surface: surface)
+
+        // White background
+        ctx.setSource(color: (red: 1, green: 1, blue: 1))
+        ctx.paint()
+
+        // Match PDFKit scaling
+        ctx.scale(x: scale, y: scale)
+        ctx.withUnsafePointer { cr in
+            page.draw(with: .mediaBox, to: cr)
+        }
+
+        surface.writePNG(atPath: url.path)
+    }
+}
+#endif

--- a/workspace-linux/Sources/Midi2Core/PDF.swift
+++ b/workspace-linux/Sources/Midi2Core/PDF.swift
@@ -4,8 +4,15 @@ import CPoppler
 import CoreGraphics
 #else
 public typealias CGPDFPage = OpaquePointer
-public typealias CGPDFBox = Int32
 public typealias CGContext = OpaquePointer
+
+public enum CGPDFBox: Int32 {
+    case mediaBox = 0
+    case cropBox = 1
+    case bleedBox = 2
+    case trimBox = 3
+    case artBox = 4
+}
 #endif
 
 public protocol PDFDocument {
@@ -48,7 +55,7 @@ public struct PopplerPDFDocument: PDFDocument {
 }
 
 public struct PopplerPDFPage: PDFPage {
-    private let page: OpaquePointer
+    let page: OpaquePointer
     init(page: OpaquePointer) { self.page = page }
 
     public var string: String? {
@@ -66,7 +73,7 @@ public struct PopplerPDFPage: PDFPage {
     }
 
     public func draw(with box: CGPDFBox, to context: CGContext) {
-        // Rendering via Poppler requires Cairo; not yet implemented.
+        poppler_page_render(page, context)
     }
 
     public func rect(for range: NSRange) -> CGRect? { nil }


### PR DESCRIPTION
## Summary
- Add PureSwift Cairo package and wire it into Midi2Core target
- Define CGPDFBox enum and implement Poppler page drawing via Cairo
- Introduce CairoRenderer that outputs PNG at the requested DPI and color space

## Testing
- `cd workspace-linux && swift test`


------
https://chatgpt.com/codex/tasks/task_b_68976e3959188333a4f993206a4bbe89