### PR TITLE
Add Poppler text extraction utilities

### DIFF
--- a/workspace-linux/Sources/Midi2Core/TextExtractor.swift
+++ b/workspace-linux/Sources/Midi2Core/TextExtractor.swift
@@ -1,0 +1,69 @@
+#if os(Linux)
+import Foundation
+import CPoppler
+
+public struct TextLine: Codable, Sendable, Equatable {
+    public let pageIndex: Int
+    public let range: NSRange
+    public let text: String
+    public let bbox: CGRect
+}
+
+public enum TextExtractor {
+    public static func extract(document pdf: PDFDocument, dpi: Double) -> [TextLine] {
+        var lines: [TextLine] = []
+        for index in 0..<pdf.pageCount {
+            guard let popplerPage = pdf.page(at: index) as? PopplerPDFPage else { continue }
+            lines.append(contentsOf: extract(page: popplerPage, pageIndex: index, dpi: dpi))
+        }
+        return lines
+    }
+
+    public static func extract(page: PopplerPDFPage, pageIndex: Int, dpi: Double) -> [TextLine] {
+        var rectsPtr: UnsafeMutablePointer<PopplerRectangle>? = nil
+        var count: UInt32 = 0
+        guard poppler_page_get_text_layout(page.page, &rectsPtr, &count) != 0,
+              let rects = rectsPtr else { return [] }
+        defer { g_free(rectsPtr) }
+
+        let fullPtr = poppler_page_get_text(page.page)
+        let fullText = fullPtr.map { String(cString: $0) } ?? ""
+        if let fp = fullPtr { g_free(fp) }
+        let nsFull = fullText as NSString
+        var searchLoc = 0
+
+        let pageHeight = Double(page.bounds(for: .mediaBox).height)
+        var out: [TextLine] = []
+
+        for i in 0..<Int(count) {
+            var rect = rects[i]
+            guard let cstr = poppler_page_get_text_for_area(page.page, &rect) else { continue }
+            let original = String(cString: cstr)
+            g_free(cstr)
+            let normalized = normalizeWhitespace(original)
+            if normalized.isEmpty { continue }
+            let range = nsFull.range(of: original, options: [], range: NSRange(location: searchLoc, length: nsFull.length - searchLoc))
+            if range.location != NSNotFound {
+                searchLoc = range.location + range.length
+            }
+            let mapped = map(rect: rect, pageHeight: pageHeight, dpi: dpi)
+            out.append(TextLine(pageIndex: pageIndex, range: range, text: normalized, bbox: mapped))
+        }
+        return out
+    }
+
+    private static func normalizeWhitespace(_ s: String) -> String {
+        let collapsed = s.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+        return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func map(rect: PopplerRectangle, pageHeight: Double, dpi: Double) -> CGRect {
+        let scale = dpi / 72.0
+        let x = rect.x1 * scale
+        let y = (pageHeight - rect.y2) * scale
+        let width = (rect.x2 - rect.x1) * scale
+        let height = (rect.y2 - rect.y1) * scale
+        return CGRect(x: x, y: y, width: width, height: height)
+    }
+}
+#endif

--- a/workspace-linux/Tests/Midi2CoreTests/Midi2CoreTests.swift
+++ b/workspace-linux/Tests/Midi2CoreTests/Midi2CoreTests.swift
@@ -2,7 +2,22 @@ import XCTest
 @testable import Midi2Core
 
 final class Midi2CoreTests: XCTestCase {
-    func testPlaceholder() throws {
-        XCTAssertNoThrow(_ = try PopplerPDFDocument(path: "/tmp/none"))
+    func testTextExtraction() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFile
+            .deletingLastPathComponent() // Midi2CoreTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // workspace-linux
+            .deletingLastPathComponent() // repo root
+        let pdfURL = repoRoot.appendingPathComponent("workspace/Inputs/M2-100-U_v1-1_MIDI_2-0_Specification_Overview.pdf")
+        let doc = try PopplerPDFDocument(path: pdfURL.path)
+        guard let page = doc.page(at: 0) as? PopplerPDFPage else {
+            XCTFail("Failed to load page")
+            return
+        }
+        let lines = TextExtractor.extract(page: page, pageIndex: 0, dpi: 72)
+        XCTAssertFalse(lines.isEmpty)
+        XCTAssert(lines.allSatisfy { !$0.text.isEmpty })
+        XCTAssert(lines.allSatisfy { $0.bbox.width > 0 && $0.bbox.height > 0 })
     }
 }


### PR DESCRIPTION
## Summary
- add TextExtractor backed by Poppler to gather text lines with bounding boxes
- normalize whitespace and map PDF coordinates to image space
- test Poppler text extraction on sample document

## Testing
- `cd workspace-linux && swift test`

------
https://chatgpt.com/codex/tasks/task_b_68977043af4883338c1a2e1e8be69327