### PR TITLE
feat: add cairo pdf rendering for facsimiles

### DIFF
--- a/workspace-linux/Sources/Midi2Core/FacsimileExporter.swift
+++ b/workspace-linux/Sources/Midi2Core/FacsimileExporter.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Linux facsimile exporter using Poppler + Cairo.
+public struct FacsimileExporter {
+    /// Render each page of `pdf` to PNG files and emit a `facsimile.html` with
+    /// deep‑link rectangles. Coordinates mirror the macOS exporter so anchors
+    /// remain stable across platforms.
+    /// - Parameters:
+    ///   - pdf: Source document.
+    ///   - docId: Identifier used for the output folder name.
+    ///   - targetRoot: Destination root folder where the doc folder will be
+    ///     created.
+    ///   - dpi: Rendering resolution (sRGB) in dots-per-inch.
+    public static func export(pdf: PDFDocument, docId: String, to targetRoot: URL, dpi: Double = 220) throws -> URL {
+        let docFolder = targetRoot.appendingPathComponent(safeSlug(docId), isDirectory: true)
+        let facsimileFolder = docFolder.appendingPathComponent("facsimile", isDirectory: true)
+        try FileManager.default.createDirectory(at: facsimileFolder, withIntermediateDirectories: true)
+
+        var pageEntries: [String] = []
+        for i in 0..<pdf.pageCount {
+            guard let page = pdf.page(at: i) else { continue }
+            let fileName = String(format: "p%03d.png", i + 1)
+            let outURL = facsimileFolder.appendingPathComponent(fileName)
+            try CairoRenderer.render(page: page, to: outURL, dpi: dpi)
+            pageEntries.append(fileName)
+        }
+
+        // Minimal facsimile.html identical to macOS exporter.
+        let html = facsimileHTML(title: docId, pages: pageEntries)
+        try html.data(using: .utf8)!.write(to: facsimileFolder.appendingPathComponent("facsimile.html"), options: .atomic)
+
+        return docFolder
+    }
+
+    private static func safeSlug(_ s: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
+        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        let replaced = trimmed.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" }
+        var out = String(replaced)
+        while out.contains("--") { out = out.replacingOccurrences(of: "--", with: "-") }
+        return out.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+
+    private static func facsimileHTML(title: String, pages: [String]) -> String {
+        var items = pages.enumerated().map { idx, fn in
+            let pid = String(format: "p%03d", idx + 1)
+            return """
+            <li id=\"\(pid)\">
+              <h3>Page \(idx + 1)</h3>
+              <div class=\"page\">
+                <img alt=\"\(pid)\" src=\"\(fn)\" loading=\"lazy\"/>
+                <div class=\"hi\" hidden></div>
+              </div>
+            </li>
+            """
+        }.joined(separator: "\n")
+        if items.isEmpty { items = "<li><em>No pages</em></li>" }
+        return #"""
+        <!doctype html>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>\#(title) — facsimile</title>
+        <style>
+        body{font:14px -apple-system,BlinkMacSystemFont,Helvetica,Arial,sans-serif;margin:20px}
+        ul{list-style:none;padding:0}
+        li{margin:12px 0}
+        .page{position:relative;display:inline-block}
+        img{max-width:100%;height:auto;box-shadow:0 0 6px rgba(0,0,0,.2)}
+        .hi{position:absolute;border:2px solid #e00;background:rgba(255,0,0,.15);pointer-events:none}
+        </style>
+        <h1>\#(title) — Facsimile</h1>
+        <ul>
+        \#(items)
+        </ul>
+        <script>
+        function applyHash() {
+          const raw = decodeURIComponent(location.hash || '').replace(/^#/, '');
+          if (!raw) return;
+          const parts = raw.split('-');
+          const p = parts[0];
+          const li = document.getElementById(p);
+          if (!li) return;
+          li.scrollIntoView({block:'start'});
+          const img = li.querySelector('img');
+          const hi = li.querySelector('.hi');
+          let x=0,y=0,w=0,h=0; let hasRect=false;
+          for (let i=1;i<parts.length;i++) {
+            const seg = parts[i];
+            if (seg.startsWith('x')) { x = parseFloat(seg.slice(1)); hasRect=true; }
+            else if (seg.startsWith('y')) { y = parseFloat(seg.slice(1)); hasRect=true; }
+            else if (seg.startsWith('w')) { w = parseFloat(seg.slice(1)); hasRect=true; }
+            else if (seg.startsWith('h')) { h = parseFloat(seg.slice(1)); hasRect=true; }
+          }
+          if (hasRect && img && hi) {
+            const scale = img.clientWidth / img.naturalWidth;
+            const left = x * scale;
+            const top = (img.naturalHeight - y - h) * scale;
+            hi.style.left = left + 'px';
+            hi.style.top = top + 'px';
+            hi.style.width = (w * scale) + 'px';
+            hi.style.height = (h * scale) + 'px';
+            hi.hidden = false;
+          } else if (hi) {
+            hi.hidden = true;
+          }
+        }
+        window.addEventListener('hashchange', applyHash);
+        window.addEventListener('load', applyHash);
+        </script>
+        """#
+    }
+
+    public enum ExportError: Error { case renderFailed }
+}

--- a/workspace-linux/Sources/midi2-export/main.swift
+++ b/workspace-linux/Sources/midi2-export/main.swift
@@ -1,8 +1,45 @@
+import Foundation
 import Midi2Core
+
+struct Args {
+    var out: URL
+    var dpi: Double
+    var docs: [URL]
+}
+
+func parseArgs() -> Args {
+    var out = URL(fileURLWithPath: FileManager.default.currentDirectoryPath).appendingPathComponent("Artifacts", isDirectory: true)
+    var dpi: Double = 220
+    var docs: [URL] = []
+    var it = CommandLine.arguments.dropFirst().makeIterator()
+    while let a = it.next() {
+        switch a {
+        case "--out": if let p = it.next() { out = URL(fileURLWithPath: p, isDirectory: true) }
+        case "--dpi": if let v = it.next(), let d = Double(v) { dpi = d }
+        default:
+            if a.hasPrefix("-") {
+                FileHandle.standardError.write(Data("Unknown flag: \(a)\n".utf8))
+                exit(2)
+            }
+            docs.append(URL(fileURLWithPath: a))
+        }
+    }
+    return Args(out: out, dpi: dpi, docs: docs)
+}
 
 @main
 struct Midi2Export {
-    static func main() {
-        print("midi2-export linux placeholder")
+    static func main() throws {
+        let args = parseArgs()
+        if args.docs.isEmpty {
+            print("Usage: midi2-export [--out <dir>] [--dpi <n>] <doc1.pdf> [doc2.pdf ...]")
+            exit(64)
+        }
+        try FileManager.default.createDirectory(at: args.out, withIntermediateDirectories: true)
+        for doc in args.docs {
+            let pdf = try PopplerPDFDocument(path: doc.path)
+            let docId = doc.deletingPathExtension().lastPathComponent
+            _ = try FacsimileExporter.export(pdf: pdf, docId: docId, to: args.out, dpi: args.dpi)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add Linux `FacsimileExporter` that rasterizes PDF pages with Cairo and builds macOS-style `facsimile.html`
- implement `midi2-export` CLI to drive the Cairo exporter

## Testing
- `swift build`
- `swift test`
- `identify -verbose /tmp/facs/M2-100-U_v1-1_MIDI_2-0_Specification_Overview/facsimile/p001.png | head -n 20`
- `python3 - <<'PY'
width_px=1870
height_px=2420
width_in=8.5
height_in=11
print(width_px/width_in)
print(height_px/height_in)
PY`

------
https://chatgpt.com/codex/tasks/task_b_689774ef85308333986c639063aa2090