### PR TITLE
Use PDF abstraction for text and table extraction

### DIFF
--- a/workspace/Sources/Midi2Core/TableExtractor.swift
+++ b/workspace/Sources/Midi2Core/TableExtractor.swift
@@ -5,7 +5,16 @@ public struct TableExtractor {
     public struct TableCell { public var rect: CGRect; public var text: String }
     public struct Table { public var pageIndex: Int; public var cells: [[TableCell]] }
 
-    public static func extract(from page: PDFPage, pageIndex: Int, tolerance: CGFloat = 2.0) -> [Table] {
+    public static func extract(document pdf: PDFDocument, tolerance: CGFloat = 2.0) -> [Table] {
+        var tables: [Table] = []
+        for pi in 0..<pdf.pageCount {
+            guard let page = pdf.page(at: pi) else { continue }
+            tables.append(contentsOf: extract(page: page, pageIndex: pi, tolerance: tolerance))
+        }
+        return tables
+    }
+
+    private static func extract(page: PDFPage, pageIndex: Int, tolerance: CGFloat) -> [Table] {
         guard let cgPage = page.pageRef else { return [] }
         let content = CGPDFContentStreamCreateWithPage(cgPage)
         let optable = CGPDFOperatorTableCreate()!

--- a/workspace/Sources/Midi2Core/TextExtractor.swift
+++ b/workspace/Sources/Midi2Core/TextExtractor.swift
@@ -9,7 +9,7 @@ public struct TextLine: Codable, Sendable, Equatable {
 
 public enum TextExtractor {
     public static func extract(document pdf: PDFDocument) -> [TextLine] {
-        // Prefer CGPDFScanner-based extraction for deterministic order; fall back to PDFKit newlines.
+        // Prefer CGPDFScanner-based extraction for deterministic order; fall back to splitting page.string by newlines.
         var lines: [TextLine] = []
         var usedCG = false
         for pi in 0..<pdf.pageCount {
@@ -18,11 +18,11 @@ public enum TextExtractor {
                 lines.append(contentsOf: mapToRanges(cgLines, on: page, pageIndex: pi))
                 usedCG = true
             } else {
-                lines.append(contentsOf: extractPageWithPDFKit(page: page, pageIndex: pi))
+                lines.append(contentsOf: extractPageWithStringSplit(page: page, pageIndex: pi))
             }
         }
         if !usedCG {
-            // All fell back to PDFKit; lines already include ranges
+            // All fell back to string splitting; lines already include ranges
             return lines
         }
         return lines
@@ -68,7 +68,7 @@ public enum TextExtractor {
     }
 
     // Fallback: split page.string by newlines
-    private static func extractPageWithPDFKit(page: PDFPage, pageIndex: Int) -> [TextLine] {
+    private static func extractPageWithStringSplit(page: PDFPage, pageIndex: Int) -> [TextLine] {
         var out: [TextLine] = []
         guard let full = page.string, !full.isEmpty else { return out }
         let scalars = Array(full)

--- a/workspace/Sources/midi2-export/main.swift
+++ b/workspace/Sources/midi2-export/main.swift
@@ -1,9 +1,6 @@
 import Foundation
 import CoreGraphics
 import Midi2Core
-#if canImport(PDFKit)
-import PDFKit
-#endif
 
 struct Args {
     var out: URL

--- a/workspace/Tests/Midi2CoreTests/TextAndTableExtractorTests.swift
+++ b/workspace/Tests/Midi2CoreTests/TextAndTableExtractorTests.swift
@@ -1,0 +1,70 @@
+#if canImport(PDFKit)
+import XCTest
+import CoreGraphics
+import CoreText
+@testable import Midi2Core
+
+final class TextAndTableExtractorTests: XCTestCase {
+    private func makePDF(at url: URL) throws {
+        var box = CGRect(x: 0, y: 0, width: 200, height: 200)
+        guard let ctx = CGContext(url as CFURL, mediaBox: &box, nil) else { throw NSError(domain: "pdf", code: 1) }
+        ctx.beginPDFPage(nil)
+
+        let font = CTFontCreateWithName("Helvetica" as CFString, 12, nil)
+        func draw(_ text: String, at point: CGPoint) {
+            let attrs: [NSAttributedString.Key: Any] = [kCTFontAttributeName as NSAttributedString.Key: font]
+            let attr = NSAttributedString(string: text, attributes: attrs)
+            let line = CTLineCreateWithAttributedString(attr)
+            ctx.textPosition = point
+            CTLineDraw(line, ctx)
+        }
+
+        // top text line
+        draw("Hello", at: CGPoint(x: 60, y: 170))
+
+        // table grid
+        ctx.setLineWidth(1)
+        ctx.addRect(CGRect(x: 50, y: 50, width: 100, height: 100))
+        ctx.move(to: CGPoint(x: 50, y: 100))
+        ctx.addLine(to: CGPoint(x: 150, y: 100))
+        ctx.move(to: CGPoint(x: 100, y: 50))
+        ctx.addLine(to: CGPoint(x: 100, y: 150))
+        ctx.strokePath()
+
+        // cell texts
+        draw("A1", at: CGPoint(x: 60, y: 130))
+        draw("B1", at: CGPoint(x: 110, y: 130))
+        draw("A2", at: CGPoint(x: 60, y: 80))
+        draw("B2", at: CGPoint(x: 110, y: 80))
+
+        ctx.endPDFPage()
+        ctx.closePDF()
+    }
+
+    func testTextExtraction() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("sample.pdf")
+        try? FileManager.default.removeItem(at: url)
+        try makePDF(at: url)
+        let pdf = try PDFKitDocument(path: url.path)
+        let lines = TextExtractor.extract(document: pdf)
+        XCTAssertEqual(lines.map { $0.text }, ["Hello", "A1", "B1", "A2", "B2"])
+    }
+
+    func testTableExtraction() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("sample.pdf")
+        try? FileManager.default.removeItem(at: url)
+        try makePDF(at: url)
+        let pdf = try PDFKitDocument(path: url.path)
+        let tables = TableExtractor.extract(document: pdf, tolerance: 0.5)
+        XCTAssertEqual(tables.count, 1)
+        guard let table = tables.first else { return }
+        XCTAssertEqual(table.pageIndex, 0)
+        XCTAssertEqual(table.cells.count, 2)
+        XCTAssertEqual(table.cells[0].count, 2)
+        XCTAssertEqual(table.cells[0][0].text, "A1")
+        XCTAssertEqual(table.cells[0][1].text, "B1")
+        XCTAssertEqual(table.cells[1][0].text, "A2")
+        XCTAssertEqual(table.cells[1][1].text, "B2")
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Switch extractors to use new `PDFDocument` abstraction and string-based fallback
- Add document-wide table extraction and update exporters
- Cover text and table extraction utilities with unit tests

## Testing
- `swift test` *(fails: no such module 'CoreGraphics')*

------
https://chatgpt.com/codex/tasks/task_b_6897776560648333b9fc16c3dd6d580d