### PR TITLE
Add ArgumentParser CLI with help and version

### DIFF
--- a/workspace/Package.resolved
+++ b/workspace/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
+        "version" : "1.6.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/workspace/Package.swift
+++ b/workspace/Package.swift
@@ -9,6 +9,9 @@ let package = Package(
         .executable(name: "MIDI2SpecReader", targets: ["MIDI2SpecReader"]),
         .executable(name: "midi2-export", targets: ["midi2-export"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
+    ],
     targets: [
         .target(
             name: "Midi2Core",
@@ -21,8 +24,14 @@ let package = Package(
         ),
         .executableTarget(
             name: "midi2-export",
-            dependencies: ["Midi2Core"],
-            path: "Sources/midi2-export"
+            dependencies: [
+                "Midi2Core",
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ],
+            path: "Sources/midi2-export",
+            resources: [
+                .copy("../../Inputs")
+            ]
         ),
         .testTarget(
             name: "Midi2CoreTests",


### PR DESCRIPTION
## Summary
- wire up Swift ArgumentParser and bundle sample resources
- refactor midi2-export to use ArgumentParser with --help and --version

## Testing
- `swift build -c release` *(fails: no such module 'CoreGraphics')*

------
https://chatgpt.com/codex/tasks/task_b_68977e13c3948333bdb54c945cb3449e