### PR TITLE
Add PDF, exporter, and CLI parsing tests

### DIFF
--- a/workspace-linux/Package.swift
+++ b/workspace-linux/Package.swift
@@ -32,6 +32,18 @@ let package = Package(
         .testTarget(
             name: "Midi2CoreTests",
             dependencies: ["Midi2Core"]
+        ),
+        .testTarget(
+            name: "PDFTests",
+            dependencies: ["Midi2Core"]
+        ),
+        .testTarget(
+            name: "ExporterTests",
+            dependencies: ["Midi2Core"]
+        ),
+        .testTarget(
+            name: "CLITests",
+            dependencies: ["midi2-export"]
         )
     ]
 )

--- a/workspace-linux/Sources/midi2-export/main.swift
+++ b/workspace-linux/Sources/midi2-export/main.swift
@@ -11,7 +11,7 @@ struct Args {
     var docs: [URL]
 }
 
-private func parsePageSpec(_ spec: String) -> [Int] {
+func parsePageSpec(_ spec: String) -> [Int] {
     var out: Set<Int> = []
     for part in spec.split(separator: ",") {
         if let dash = part.firstIndex(of: "-") {
@@ -27,7 +27,7 @@ private func parsePageSpec(_ spec: String) -> [Int] {
     return out.sorted()
 }
 
-func parseArgs() -> Args {
+func parseArgs(_ arguments: [String] = CommandLine.arguments) -> Args {
     var out = URL(fileURLWithPath: FileManager.default.currentDirectoryPath).appendingPathComponent("Artifacts", isDirectory: true)
     var dpi: Double = 220
     var pages: [Int]? = nil
@@ -35,7 +35,7 @@ func parseArgs() -> Args {
     var exportReadable = false
     var verbose = 0
     var docs: [URL] = []
-    var it = CommandLine.arguments.dropFirst().makeIterator()
+    var it = arguments.dropFirst().makeIterator()
     while let a = it.next() {
         switch a {
         case "--out": if let p = it.next() { out = URL(fileURLWithPath: p, isDirectory: true) }

--- a/workspace-linux/Tests/CLITests/CLITests.swift
+++ b/workspace-linux/Tests/CLITests/CLITests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import midi2_export
+
+final class CLITests: XCTestCase {
+    func testParsePageSpec() {
+        XCTAssertEqual(parsePageSpec("1,3-5,7"), [1,3,4,5,7])
+        XCTAssertEqual(parsePageSpec("2-2,4"), [2,4])
+    }
+
+    func testParseArgs() {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let fixtures = testFile
+            .deletingLastPathComponent() // CLITests
+            .deletingLastPathComponent() // Tests
+            .appendingPathComponent("Fixtures")
+        let pdfPath = fixtures.appendingPathComponent("sample.pdf").path
+        let outDir = fixtures.appendingPathComponent("cli-out").path
+        let args = parseArgs(["midi2-export", "--out", outDir, "--dpi", "144", "--pages", "1,2-3", "--facsimile", pdfPath])
+        XCTAssertEqual(args.out.path, outDir)
+        XCTAssertEqual(args.dpi, 144)
+        XCTAssertEqual(args.pages!, [1,2,3])
+        XCTAssertTrue(args.exportFacsimile)
+        XCTAssertFalse(args.exportReadable)
+        XCTAssertEqual(args.docs.map { $0.path }, [pdfPath])
+    }
+}

--- a/workspace-linux/Tests/ExporterTests/ExporterTests.swift
+++ b/workspace-linux/Tests/ExporterTests/ExporterTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import Midi2Core
+
+final class ExporterTests: XCTestCase {
+    func testFacsimileExportProducesHTMLAndPNG() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let fixtures = testFile
+            .deletingLastPathComponent() // ExporterTests
+            .deletingLastPathComponent() // Tests
+            .appendingPathComponent("Fixtures")
+        let pdfURL = fixtures.appendingPathComponent("sample.pdf")
+        let expectedHTMLURL = fixtures.appendingPathComponent("expected-facsimile.html")
+        let pdf = try PopplerPDFDocument(path: pdfURL.path)
+        let tempRoot = fixtures.appendingPathComponent("out")
+        try? FileManager.default.removeItem(at: tempRoot)
+        let out = try FacsimileExporter.export(pdf: pdf, docId: "sample", to: tempRoot, dpi: 72)
+        let htmlURL = out.appendingPathComponent("facsimile/facsimile.html")
+        let pngURL = out.appendingPathComponent("facsimile/p001.png")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: pngURL.path))
+        let html = try String(contentsOf: htmlURL, encoding: .utf8)
+        let expected = try String(contentsOf: expectedHTMLURL, encoding: .utf8)
+        XCTAssertEqual(html, expected)
+        try? FileManager.default.removeItem(at: tempRoot)
+    }
+}

--- a/workspace-linux/Tests/Fixtures/expected-facsimile.html
+++ b/workspace-linux/Tests/Fixtures/expected-facsimile.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>sample — facsimile</title>
+<style>
+body{font:14px -apple-system,BlinkMacSystemFont,Helvetica,Arial,sans-serif;margin:20px}
+ul{list-style:none;padding:0}
+li{margin:12px 0}
+.page{position:relative;display:inline-block}
+img{max-width:100%;height:auto;box-shadow:0 0 6px rgba(0,0,0,.2)}
+.hi{position:absolute;border:2px solid #e00;background:rgba(255,0,0,.15);pointer-events:none}
+</style>
+<h1>sample — Facsimile</h1>
+<ul>
+<li id="p001">
+  <h3>Page 1</h3>
+  <div class="page">
+    <img alt="p001" src="p001.png" loading="lazy"/>
+    <div class="hi" hidden></div>
+  </div>
+</li>
+</ul>
+<script>
+function applyHash() {
+  const raw = decodeURIComponent(location.hash || '').replace(/^#/, '');
+  if (!raw) return;
+  const parts = raw.split('-');
+  const p = parts[0];
+  const li = document.getElementById(p);
+  if (!li) return;
+  li.scrollIntoView({block:'start'});
+  const img = li.querySelector('img');
+  const hi = li.querySelector('.hi');
+  let x=0,y=0,w=0,h=0; let hasRect=false;
+  for (let i=1;i<parts.length;i++) {
+    const seg = parts[i];
+    if (seg.startsWith('x')) { x = parseFloat(seg.slice(1)); hasRect=true; }
+    else if (seg.startsWith('y')) { y = parseFloat(seg.slice(1)); hasRect=true; }
+    else if (seg.startsWith('w')) { w = parseFloat(seg.slice(1)); hasRect=true; }
+    else if (seg.startsWith('h')) { h = parseFloat(seg.slice(1)); hasRect=true; }
+  }
+  if (hasRect && img && hi) {
+    const scale = img.clientWidth / img.naturalWidth;
+    const left = x * scale;
+    const top = (img.naturalHeight - y - h) * scale;
+    hi.style.left = left + 'px';
+    hi.style.top = top + 'px';
+    hi.style.width = (w * scale) + 'px';
+    hi.style.height = (h * scale) + 'px';
+    hi.hidden = false;
+  } else if (hi) {
+    hi.hidden = true;
+  }
+}
+window.addEventListener('hashchange', applyHash);
+window.addEventListener('load', applyHash);
+</script>

--- a/workspace-linux/Tests/Fixtures/sample.pdf
+++ b/workspace-linux/Tests/Fixtures/sample.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 200 200 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250809170822+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250809170822+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 99
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CW4KISh_&dAOI+h7pu*iV.[q$I-TDOLnU=UH<U+I*:=!8,s:bl~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
+trailer
+<<
+/ID 
+[<e90fa64138f5bbe70db5c8b2afb1194f><e90fa64138f5bbe70db5c8b2afb1194f>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1015
+%%EOF

--- a/workspace-linux/Tests/Fixtures/sample.txt
+++ b/workspace-linux/Tests/Fixtures/sample.txt
@@ -1,0 +1,1 @@
+Hello PDF

--- a/workspace-linux/Tests/PDFTests/PDFTests.swift
+++ b/workspace-linux/Tests/PDFTests/PDFTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import Midi2Core
+
+final class PDFTests: XCTestCase {
+    func testSamplePDF() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let fixtures = testFile
+            .deletingLastPathComponent() // PDFTests
+            .deletingLastPathComponent() // Tests
+            .appendingPathComponent("Fixtures")
+        let pdfURL = fixtures.appendingPathComponent("sample.pdf")
+        let textURL = fixtures.appendingPathComponent("sample.txt")
+        let expected = try String(contentsOf: textURL).trimmingCharacters(in: .whitespacesAndNewlines)
+        let pdf = try PopplerPDFDocument(path: pdfURL.path)
+        XCTAssertEqual(pdf.pageCount, 1)
+        guard let page = pdf.page(at: 0) else {
+            return XCTFail("Missing page")
+        }
+        let extracted = page.string?.trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertEqual(extracted, expected)
+    }
+}


### PR DESCRIPTION
## Summary
- add PDFTests, ExporterTests, and CLITests targets with fixtures
- expose CLI parsing helpers and refactor argument handling
- cover PDF abstraction, facsimile export, and command-line parsing

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68977fc7d66c8333b8e48875bdfad24f